### PR TITLE
Move imports from engine to ruby_rpg

### DIFF
--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -1,45 +1,4 @@
-require 'opengl'
-require 'glfw'
-require 'concurrent'
-require 'os'
-
-require_relative "debugging"
-require_relative 'rendering/render_pipeline'
-require_relative 'rendering/instance_renderer'
-require_relative 'screenshoter'
-require_relative 'input'
-require_relative "quaternion"
-require_relative 'game_object'
-require_relative 'texture'
-require_relative 'material'
-require_relative 'mesh'
-require_relative "font"
-require_relative 'path'
-require_relative 'polygon_mesh'
-require_relative 'importers/obj_file'
-require_relative 'tangent_calculator'
-require_relative 'shader'
-require_relative 'component'
-require_relative "camera"
-require_relative "window"
-require_relative "video_mode"
-require_relative "cursor"
-
-require_relative "components/orthographic_camera"
-require_relative "components/perspective_camera"
-require_relative "components/sprite_renderer"
-require_relative "components/ui_sprite_renderer"
-require_relative "components/mesh_renderer"
-require_relative "components/font_renderer"
-require_relative "components/ui_font_renderer"
-require_relative "components/point_light"
-require_relative "components/direction_light"
-
-require_relative "physics/physics_resolver"
-require_relative 'physics/collision'
-require_relative "physics/components/sphere_collider"
-require_relative "physics/components/cube_collider"
-require_relative "physics/components/rigidbody"
+# frozen_string_literal: true
 
 if OS.windows?
   GLFW.load_lib(File.expand_path(File.join(__dir__, "..", "..", "glfw-3.4.bin.WIN64", "lib-static-ucrt", "glfw3.dll")))

--- a/lib/ruby_rpg.rb
+++ b/lib/ruby_rpg.rb
@@ -1,3 +1,47 @@
 # frozen_string_literal: true
 
+require 'opengl'
+require 'glfw'
+require 'concurrent'
+require 'os'
+
+require_relative "engine/debugging"
+require_relative 'engine/rendering/render_pipeline'
+require_relative 'engine/rendering/instance_renderer'
+require_relative 'engine/screenshoter'
+require_relative 'engine/input'
+require_relative "engine/quaternion"
+require_relative 'engine/game_object'
+require_relative 'engine/texture'
+require_relative 'engine/material'
+require_relative 'engine/mesh'
+require_relative "engine/font"
+require_relative 'engine/path'
+require_relative 'engine/polygon_mesh'
+require_relative 'engine/importers/obj_file'
+require_relative 'engine/tangent_calculator'
+require_relative 'engine/shader'
+require_relative 'engine/component'
+require_relative "engine/camera"
+require_relative "engine/window"
+require_relative "engine/video_mode"
+require_relative "engine/cursor"
+
+require_relative "engine/components/orthographic_camera"
+require_relative "engine/components/perspective_camera"
+require_relative "engine/components/sprite_renderer"
+require_relative "engine/components/ui_sprite_renderer"
+require_relative "engine/components/mesh_renderer"
+require_relative "engine/components/font_renderer"
+require_relative "engine/components/ui_font_renderer"
+require_relative "engine/components/point_light"
+require_relative "engine/components/direction_light"
+
+require_relative "engine/physics/physics_resolver"
+require_relative 'engine/physics/collision'
+require_relative "engine/physics/components/sphere_collider"
+require_relative "engine/physics/components/cube_collider"
+require_relative "engine/physics/components/rigidbody"
+
+
 require_relative 'engine/engine'

--- a/samples/asteroids/asteroids.rb
+++ b/samples/asteroids/asteroids.rb
@@ -1,4 +1,4 @@
-require_relative "../../lib/engine/engine"
+require_relative "../../lib/ruby_rpg"
 require "pry"
 
 ROOT = File.expand_path(File.join(__dir__))

--- a/samples/cubes/cubes.rb
+++ b/samples/cubes/cubes.rb
@@ -1,4 +1,4 @@
-require_relative "../../lib/engine/engine"
+require_relative "../../lib/ruby_rpg"
 
 ROOT = File.expand_path(File.join(__dir__))
 ASSETS_DIR = File.expand_path(File.join(__dir__, "assets"))

--- a/samples/shrink_racer/shrink_racer.rb
+++ b/samples/shrink_racer/shrink_racer.rb
@@ -1,4 +1,4 @@
-require_relative "../../lib/engine/engine"
+require_relative "../../lib/ruby_rpg"
 require "pry"
 
 ROOT = File.expand_path(File.join(__dir__))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require_relative "../lib/engine/engine"
+require_relative "../lib/ruby_rpg"
 require_relative "support/test_driver"
 
 Dir[File.join(__dir__,"support", "**/*.rb")].each {|f| require f}


### PR DESCRIPTION
This is to clean up the engine file that is getting too full.

These imports should be done at the very root of everything.
