### PR TITLE
Defer the destruction of game objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # /temp/ folders
 **/temp/
+
+# rspec examples
+spec/examples.txt

--- a/lib/engine/component.rb
+++ b/lib/engine/component.rb
@@ -30,8 +30,12 @@ module Engine
     end
 
     def destroy!
+      Component.destroyed_components << self unless @destroyed
+      destroy unless @destroyed
       @destroyed = true
-      destroy
+    end
+
+    def _erase!
       game_object.components.delete(self)
       class_name = self.class.name.split('::').last
       self.class.instance_variable_get(:@methods).each do |method|
@@ -42,7 +46,18 @@ module Engine
       end
     end
 
+    def self.erase_destroyed_components
+      destroyed_components.each do |object|
+        object._erase!
+      end
+      @destroyed_components = []
+    end
+
     def destroy
+    end
+
+    def self.destroyed_components
+      @destroyed_components ||= []
     end
   end
 end

--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -59,6 +59,7 @@ module Engine
       print_fps(delta_time)
       Physics::PhysicsResolver.resolve
       GameObject.update_all(delta_time)
+      GameObject.erase_destroyed_objects
 
       @swap_buffers_promise.wait! if @swap_buffers_promise
       GL.Clear(GL::COLOR_BUFFER_BIT | GL::DEPTH_BUFFER_BIT)
@@ -95,6 +96,7 @@ module Engine
 
   def self.close
     GameObject.destroy_all
+    GameObject.erase_destroyed_objects
     GLFW.SetWindowShouldClose(Window.window, 1)
   end
 
@@ -102,6 +104,7 @@ module Engine
     @game_stopped = true
     @swap_buffers_promise.wait! if @swap_buffers_promise && !@swap_buffers_promise.complete?
     GameObject.destroy_all
+    GameObject.erase_destroyed_objects
   end
 
   private

--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -59,7 +59,6 @@ module Engine
       print_fps(delta_time)
       Physics::PhysicsResolver.resolve
       GameObject.update_all(delta_time)
-      GameObject.erase_destroyed_objects
 
       @swap_buffers_promise.wait! if @swap_buffers_promise
       GL.Clear(GL::COLOR_BUFFER_BIT | GL::DEPTH_BUFFER_BIT)
@@ -96,6 +95,7 @@ module Engine
 
   def self.close
     GameObject.destroy_all
+    Component.erase_destroyed_components
     GameObject.erase_destroyed_objects
     GLFW.SetWindowShouldClose(Window.window, 1)
   end
@@ -104,6 +104,7 @@ module Engine
     @game_stopped = true
     @swap_buffers_promise.wait! if @swap_buffers_promise && !@swap_buffers_promise.complete?
     GameObject.destroy_all
+    Component.erase_destroyed_components
     GameObject.erase_destroyed_objects
   end
 

--- a/lib/engine/game_object.rb
+++ b/lib/engine/game_object.rb
@@ -132,15 +132,16 @@ module Engine
 
     def destroy!
       return unless GameObject.objects.include?(self)
-      @destroyed = true
       children.each(&:destroy!)
-      GameObject.destroyed_objects << self unless GameObject.destroyed_objects.include?(self)
-    end
-
-    def _erase!
       components.each(&:destroy!)
       ui_renderers.each(&:destroy!)
       renderers.each(&:destroy!)
+
+      GameObject.destroyed_objects << self unless @destroyed
+      @destroyed = true
+    end
+
+    def _erase!
       GameObject.objects.delete(self)
       parent.children.delete(self) if parent
       name = @name
@@ -185,6 +186,9 @@ module Engine
       GameObject.objects.each do |object|
         object.components.each { |component| component.update(delta_time) }
       end
+      
+      Component.erase_destroyed_components
+      GameObject.erase_destroyed_objects
     end
 
     def self.mesh_renderers

--- a/spec/engine/component_spec.rb
+++ b/spec/engine/component_spec.rb
@@ -25,12 +25,14 @@ describe Engine::Component do
       expect(component).to receive(:destroy)
 
       component.destroy!
+      Engine::Component.erase_destroyed_components
 
       expect(game_object.components).to be_empty
     end
 
     it 'undefines the methods' do
       component.destroy!
+      Engine::Component.erase_destroyed_components
 
       expect { component.start }.to raise_error("This Component has been destroyed but you are still trying to access start")
       expect { component.update(0) }.to raise_error("This Component has been destroyed but you are still trying to access update")

--- a/spec/engine/game_object_spec.rb
+++ b/spec/engine/game_object_spec.rb
@@ -203,6 +203,7 @@ describe Engine::GameObject do
       object = Engine::GameObject.new
 
       object.destroy!
+      Engine::GameObject.erase_destroyed_objects
       expect(Engine::GameObject.objects).not_to include(object)
     end
 
@@ -222,6 +223,7 @@ describe Engine::GameObject do
       object2 = Engine::GameObject.new("b")
 
       Engine::GameObject.destroy_all
+      Engine::GameObject.erase_destroyed_objects
       expect(Engine::GameObject.objects).to be_empty
     end
   end
@@ -288,6 +290,7 @@ describe Engine::GameObject do
       object = Engine::GameObject.new(parent: parent)
 
       object.destroy!
+      Engine::GameObject.erase_destroyed_objects
 
       expect(parent.children).not_to include(object)
     end
@@ -297,6 +300,7 @@ describe Engine::GameObject do
       object = Engine::GameObject.new(parent: parent)
 
       parent.destroy!
+      Engine::GameObject.erase_destroyed_objects
 
       expect(Engine::GameObject.objects).not_to include(object)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ require_relative "support/test_driver"
 Dir[File.join(__dir__,"support", "**/*.rb")].each {|f| require f}
 
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Defering the destruction of game objects until after the frame means that bugs wehre an object is destroyed and you access it in the same frame happen less.

A developer will still need to clean up after themselves for the next frame but it's not as confusing as objects being destroyed right away and losing the ability to access them. This way we can have one guard at the start of the frame and know we are safe for the duration of that frame to access the data of the object.

