### PR TITLE
Enable vsync on Windows to fix borderless FPS drop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_rpg (0.1.9)
+    ruby_rpg (0.1.10)
       chunky_png (~> 1.4)
       concurrent-ruby
       fiddle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_rpg (0.1.10)
+    ruby_rpg (0.1.11)
       chunky_png (~> 1.4)
       concurrent-ruby
       fiddle

--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -39,7 +39,7 @@ module Engine
     Engine::GL.Enable(Engine::GL::CULL_FACE)
     Engine::GL.CullFace(Engine::GL::BACK)
 
-    GLFW.SwapInterval(0)
+    GLFW.SwapInterval(OS.windows? ? 1 : 0)
   end
 
   def self.main_game_loop(&first_frame_block)

--- a/ruby_rpg.gemspec
+++ b/ruby_rpg.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'ruby_rpg'
-  s.version = '0.1.10'
+  s.version = '0.1.11'
   s.authors = ['Max Hatfull']
   s.email = "max.hatfull@gmail.com"
   s.summary = "A game engine written in Ruby"


### PR DESCRIPTION
## Problem

Switching to a borderless window dropped Windows from several hundred FPS to a stuttery ~30 on high-end hardware. Not noticeable on macOS.

## Cause

A borderless window on Windows is always composited by the DWM, which ignores `SwapInterval(0)` and force-syncs to the refresh rate. Left at `0`, the driver sits in a "vsync off but still composited" state, misses vblank deadlines, and stalls to half-rate (e.g. 30 on a 60Hz panel).

## Fix

Enable vsync on Windows only (`SwapInterval(1)`), so frames pace cleanly to a stable refresh-rate cap (60, or 144 on a high-refresh panel) instead of the half-rate stutter. macOS is left uncapped — it already composites at the panel rate and swaps on a background thread.

```
BEFORE (Windows)              AFTER (Windows)
vsync off, but composited     vsync on
→ misses vblank → 30 fps      → paces to vblank → steady 60/144
```

Trade-off: borderless OpenGL can't reliably get uncapped FPS back on Windows — that requires exclusive fullscreen. This keeps the borderless window (good alt-tab + Steam overlay behaviour) and makes it smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)