### PR TITLE
Add Linux support: GLEW init and main-thread buffer swap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglfw3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglfw3-dev libglew-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/ext/gl_native/extconf.rb
+++ b/ext/gl_native/extconf.rb
@@ -2,6 +2,10 @@
 
 require 'mkmf'
 
+# A GL call with no prototype gets an implicit int return, which truncates
+# pointers on 64-bit — fail the build instead
+$CFLAGS << " -Werror=implicit-function-declaration" unless RUBY_PLATFORM =~ /mswin/
+
 # Find OpenGL
 case RUBY_PLATFORM
 when /darwin/

--- a/ext/gl_native/extconf.rb
+++ b/ext/gl_native/extconf.rb
@@ -9,6 +9,7 @@ when /darwin/
   $CFLAGS << " -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Headers"
 when /linux/
   have_library('GL') or abort "OpenGL not found"
+  have_library('GLEW') or abort "GLEW not found (install libglew-dev)"
 when /mingw|mswin/
   glew_dir = File.expand_path('../../../vendor/glew-2.2.0-win32', __FILE__)
   $CFLAGS << " -I#{glew_dir}/include"

--- a/ext/gl_native/gl_native.c
+++ b/ext/gl_native/gl_native.c
@@ -6,7 +6,7 @@
 extern void glBindImageTexture(GLuint unit, GLuint texture, GLint level, GLboolean layered, GLint layer, GLenum access, GLenum format);
 extern void glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y, GLuint num_groups_z);
 extern void glMemoryBarrier(GLbitfield barriers);
-#elif defined(_WIN32) || defined(__MINGW32__)
+#elif defined(_WIN32) || defined(__MINGW32__) || defined(__linux__)
 #include <GL/glew.h>
 #else
 #include <GL/gl.h>
@@ -490,9 +490,9 @@ static VALUE rb_gl_memory_barrier(VALUE self, VALUE barriers) {
     return Qnil;
 }
 
-/* Initialize GLEW (Windows only) */
+/* Initialize GLEW (Windows and Linux) */
 static VALUE rb_gl_init_glew(VALUE self) {
-#if defined(_WIN32) || defined(__MINGW32__)
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__linux__)
     GLenum err = glewInit();
     if (err != GLEW_OK) {
         rb_raise(rb_eRuntimeError, "Failed to initialize GLEW: %s", glewGetErrorString(err));
@@ -579,6 +579,6 @@ void Init_gl_native(void) {
     rb_define_module_function(mGLNative, "dispatch_compute", rb_gl_dispatch_compute, 3);
     rb_define_module_function(mGLNative, "memory_barrier", rb_gl_memory_barrier, 1);
 
-    /* GLEW initialization (Windows only, no-op on other platforms) */
+    /* GLEW initialization (Windows and Linux, no-op on macOS) */
     rb_define_module_function(mGLNative, "init_glew", rb_gl_init_glew, 0);
 }

--- a/lib/engine/engine.rb
+++ b/lib/engine/engine.rb
@@ -39,7 +39,7 @@ module Engine
     Engine::GL.Enable(Engine::GL::CULL_FACE)
     Engine::GL.CullFace(Engine::GL::BACK)
 
-    GLFW.SwapInterval(OS.windows? ? 1 : 0)
+    GLFW.SwapInterval(OS.mac? ? 0 : 1)
   end
 
   def self.main_game_loop(&first_frame_block)
@@ -74,13 +74,16 @@ module Engine
 
       Window.get_framebuffer_size
 
-      if OS.windows?
-        GLFW.SwapBuffers(Window.window)
-      else
+      if OS.mac?
+        # Async swap keeps the main thread free while waiting on the display link
         @swap_buffers_promise = Concurrent::Promise.new do
           GLFW.SwapBuffers(Window.window)
         end
         @swap_buffers_promise.execute
+      else
+        # GLX requires SwapBuffers on the thread owning the context, so
+        # Windows and Linux swap synchronously
+        GLFW.SwapBuffers(Window.window)
       end
 
       Engine::Input.update_key_states

--- a/ruby_rpg.gemspec
+++ b/ruby_rpg.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'ruby_rpg'
-  s.version = '0.1.11'
+  s.version = '0.1.12'
   s.authors = ['Max Hatfull']
   s.email = "max.hatfull@gmail.com"
   s.summary = "A game engine written in Ruby"


### PR DESCRIPTION
## Summary
Two engine-level blockers for a Linux build:

- **GLEW was never enabled on Linux** — `gl_native` compiled against plain `GL/gl.h`, which only declares OpenGL 1.x. The engine needs shaders, FBOs, and compute (GL 4.3+). Linux now includes `GL/glew.h`, links `-lGLEW` (build needs `libglew-dev`), and actually runs `glewInit()` (previously a Windows-only no-op).
- **Async SwapBuffers is invalid on Linux** — GLX requires the context to be current on the thread calling SwapBuffers, but the context lives on the main thread. The background-thread swap promise is now macOS-only; Windows and Linux swap synchronously, with vsync enabled (macOS keeps vsync off + async swap, unchanged).

## Testing
- macOS: `rake compile` passes and the engine loads; mac code paths are behaviorally unchanged.
- Linux: compile path not yet exercised — will get its first real test when the Linux packaging CI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)