### PR TITLE
Read shader sources with explicit UTF-8 encoding

### DIFF
--- a/lib/engine/shader.rb
+++ b/lib/engine/shader.rb
@@ -136,7 +136,9 @@ module Engine
       return "" if included.include?(path)
       included << path
 
-      source = File.read(path)
+      # Explicit encoding: the locale (and thus Ruby's default external
+      # encoding) is unreliable inside the Steam Linux Runtime container
+      source = File.read(path, encoding: Encoding::UTF_8)
       dir = File.dirname(path)
 
       source.gsub(/#include\s+"([^"]+)"/) do

--- a/lib/engine/shaders/mesh_frag.glsl
+++ b/lib/engine/shaders/mesh_frag.glsl
@@ -24,7 +24,7 @@ uniform float roughness = 0.5;
 void main()
 {
     // Sample texture and apply base colour tint
-    // (nil textures → white 1x1, baseColour defaults to white in Material)
+    // (nil textures -> white 1x1, baseColour defaults to white in Material)
     vec4 texSample = texture(image, TexCoord);
     vec3 colour = texSample.rgb * baseColour;
 


### PR DESCRIPTION
## Problem

First Steam Deck run of Impulse Response's Linux build crashed at startup:

```
ArgumentError: invalid byte sequence in US-ASCII
  engine/shader.rb:142 'gsub' in preprocess_shader
```

Ruby derives its default external encoding from the locale. In shipped environments that's unreliable — the Steam Linux Runtime container can be handed a `LANG` naming a locale it doesn't have, and macOS apps launched from Finder get no locale at all. Ruby then silently falls back to **US-ASCII**, and `File.read` of `mesh_frag.glsl` (which had a `→` in a comment) produces a string that blows up in `gsub`.

## Fix

- `preprocess_shader` reads shader sources with explicit `Encoding::UTF_8` so it no longer depends on the environment.
- The `→` in the `mesh_frag.glsl` comment becomes `->` — some strict GLSL compilers reject non-ASCII bytes even in comments. This was the only non-ASCII byte in any shipped shader.

A companion PR in impulse_response (MaxHatfull/impulse_response#117) passes `-EUTF-8` to Ruby in the launchers, which protects all other text asset reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)